### PR TITLE
Fix the entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,5 @@ COPY sql_transfer/ /sql_transfer
 COPY requirements.txt requirements.txt
 COPY openssl.cnf /etc/ssl/openssl.cnf
 RUN pip install -r requirements.txt && pip freeze
+
+ENTRYPOINT ["python", "sql_transfer/sql_transfer.py"]

--- a/DockerfileTest
+++ b/DockerfileTest
@@ -21,4 +21,4 @@ RUN pip install \
 RUN mkdir /tests
 COPY ./tests /tests
 
-CMD ['pytest', '/tests', '--verbose']
+ENTRYPOINT ['pytest']

--- a/test.sh
+++ b/test.sh
@@ -26,5 +26,6 @@ docker run \
   -v /var/lib/docker:/var/lib/docker \
   -e POSTGRES_TEST_IMAGE=$POSTGRES_TEST_IMAGE \
   -e SQL_SERVER_IMAGE=$SQL_SERVER_IMAGE \
+  --entrypoint pytest \
   docker_sql_transfer:dev-test \
-  pytest /tests -vrA --color=yes
+  /tests -vrA --color=yes


### PR DESCRIPTION
The entrypoint pre-commit was set to python and the user had to specify the path to the py file. The appropriate file is being called directly now so the user only needs to specify the command line arguments.